### PR TITLE
Add support for pineapple zip files

### DIFF
--- a/MainWindow.cs
+++ b/MainWindow.cs
@@ -352,7 +352,6 @@ namespace Yuzu_Updater
                     if (gitResponse.IsSuccessStatusCode)
                     {
 
-                        var str = await gitResponse.Content.ReadAsStringAsync();
                         var gitContent = JsonConvert.DeserializeObject<GithubRealeaseJSON>(await gitResponse.Content.ReadAsStringAsync());
 
                         var archivePath = gitContent.assets.Select(asset => asset.browser_download_url).FirstOrDefault(fileUrl =>

--- a/MainWindow.cs
+++ b/MainWindow.cs
@@ -5,12 +5,14 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Threading;
+using Newtonsoft.Json;
 using static Yuzu_Updater.DownloadManager;
 
 namespace Yuzu_Updater
@@ -321,6 +323,17 @@ namespace Yuzu_Updater
                 logger.Log(LogLevel.ERROR, e.StackTrace);
             }
         }
+        class GithubReleaseAsset
+        {
+            public string browser_download_url { get; set; }
+        }
+        class GithubRealeaseJSON
+        {
+            
+
+            public IEnumerable<GithubReleaseAsset> assets { get; set; }
+        }
+
         private async Task DownloadVersion(string version, bool replaceAsLatest)
         {
             try
@@ -331,19 +344,30 @@ namespace Yuzu_Updater
                     SetControlsEnabled(false);
 
                     var gitUrl = "https://github.com/pineappleEA/pineapple-src/releases/tag/EA-";
-                    var gitLink = gitUrl + version;
+                    var gitLink = "https://api.github.com/repos/pineappleEA/pineapple-src/releases/tags/EA-" + version;
 
                     var anonResponse = await httpClient.GetAsync(archivedVersions[version]);
                     var gitResponse = await httpClient.GetAsync(gitLink);
 
                     if (gitResponse.IsSuccessStatusCode)
                     {
-                        String fileName = "Windows-Yuzu-EA-" + version + ".7z";
-                        String address = gitLink.Replace("tag","download") + "/Windows-Yuzu-EA-" + version + ".7z";
+
+                        var str = await gitResponse.Content.ReadAsStringAsync();
+                        var gitContent = JsonConvert.DeserializeObject<GithubRealeaseJSON>(await gitResponse.Content.ReadAsStringAsync());
+
+                        var archivePath = gitContent.assets.Select(asset => asset.browser_download_url).FirstOrDefault(fileUrl =>
+                            fileUrl.Contains("Windows-Yuzu-EA") && (fileUrl.EndsWith(".7z") || fileUrl.EndsWith(".zip")));
+
+                        if (string.IsNullOrEmpty(archivePath))
+                        {
+                            throw new Exception($"Could not find archived file for release ${version} at ${gitLink}");
+                        }
+
+                        var fileName = Path.GetFileName(archivePath);
                         if (settings.AcceleratedDownloads)
                         {
 
-                            DownloadResult downloadResult = await DownloadManager.Download(address, Directory.GetCurrentDirectory(), settings.MaxConnections, ArchiveOctaneClient_DownloadProgressChanged);
+                            DownloadResult downloadResult = await DownloadManager.Download(archivePath, Directory.GetCurrentDirectory(), settings.MaxConnections, ArchiveOctaneClient_DownloadProgressChanged);
                             SetStatus($"Download Took: {downloadResult.TimeTaken}");
                             ArchiveDownloadCompleted(new FileDownloadInfo(fileName, version, replaceAsLatest));
                         }
@@ -355,7 +379,7 @@ namespace Yuzu_Updater
                                 archiveWebClient.DownloadProgressChanged += ArchiveWebClient_DownloadProgressChanged;
                                 archiveWebClient.DownloadFileCompleted += ArchiveWebClient_DownloadFileCompleted;
                                 stopwatch.Start();
-                                archiveWebClient.DownloadFileAsync(new Uri(address), Directory.GetCurrentDirectory() + "\\" + fileName, new FileDownloadInfo(Directory.GetCurrentDirectory() + "\\" + fileName, version, replaceAsLatest));
+                                archiveWebClient.DownloadFileAsync(new Uri(archivePath), Directory.GetCurrentDirectory() + "\\" + fileName, new FileDownloadInfo(Directory.GetCurrentDirectory() + "\\" + fileName, version, replaceAsLatest));
                             }
                         }
                     }

--- a/Yuzu Updater.csproj
+++ b/Yuzu Updater.csproj
@@ -15,6 +15,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <IsWebBootstrapper>false</IsWebBootstrapper>
+    <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
     <UpdateEnabled>false</UpdateEnabled>
@@ -78,6 +79,9 @@
   <ItemGroup>
     <Reference Include="7z.NET, Version=1.0.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\7z.NET.1.0.3\lib\net46\7z.NET.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Yuzu Updater.csproj.user
+++ b/Yuzu Updater.csproj.user
@@ -8,6 +8,7 @@
     <ErrorReportUrlHistory />
     <FallbackCulture>en-US</FallbackCulture>
     <VerifyUploadedFiles>false</VerifyUploadedFiles>
+    <PublishUrlHistory />
   </PropertyGroup>
   <PropertyGroup>
     <EnableSecurityDebugging>false</EnableSecurityDebugging>

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="7z.NET" version="1.0.3" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Pineapple stores their releases as zip files. This fetches the release as JSON, grabs the browser download link, and downloads the zip file.
The existing 7zip code works for unzipping this archive.